### PR TITLE
Use 'sha256 :no_check' as advised by 'brew cask audit nasas-eyes'

### DIFF
--- a/Casks/nasas-eyes.rb
+++ b/Casks/nasas-eyes.rb
@@ -1,6 +1,6 @@
 cask 'nasas-eyes' do
   version :latest
-  sha256 'cb5c7a506895f5ff585252e4d6e0d9722aacfda91db90b15865a172425e4e925'
+  sha256 :no_check
 
   url 'https://eyes.jpl.nasa.gov/eyesproduct/EYES/os/osx'
   name "NASA's Eyes"


### PR DESCRIPTION
`version :latest` needs `sha256 :no_check` so new versions don't mismatch.